### PR TITLE
Optimized the Todo /add logic to only return the new Todo instead of the whole list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.1'
-    id 'io.spring.dependency-management' version '1.1.0'
-    id 'org.graalvm.buildtools.native' version '0.9.23'
+    id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.5'
+    id 'org.graalvm.buildtools.native' version '0.10.2'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '17'
+    sourceCompatibility = '21'
 }
 
 repositories {
@@ -22,7 +22,6 @@ configurations {
     }
 }
 
-
 dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
@@ -32,7 +31,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'io.github.wimdeblauwe:htmx-spring-boot-thymeleaf:2.0.1'
+    implementation 'io.github.wimdeblauwe:htmx-spring-boot-thymeleaf:3.4.1'
 
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/example/htmx/HtmxApplication.java
+++ b/src/main/java/com/example/htmx/HtmxApplication.java
@@ -1,6 +1,6 @@
 package com.example.htmx;
 
-import io.github.wimdeblauwe.hsbt.mvc.HtmxResponse;
+import io.github.wimdeblauwe.htmx.spring.boot.mvc.HtmxResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -40,8 +40,9 @@ class Initializer {
     @EventListener({ApplicationReadyEvent.class, TodosResetEvent.class})
     void reset() {
         this.repository.deleteAll();
-        Stream.of("write a new blog,record a video on HTMX,record a new podcast episode".split(","))
-                .forEach(t -> this.repository.save(new Todo(null, t)));
+        Stream.of(("write a new blog,record a video on HTMX, record a new podcast episode")
+                .split(","))
+            .forEach(t -> this.repository.save(new Todo(null, t)));
     }
 }
 
@@ -70,17 +71,18 @@ class TodosController {
     String reset(Model model) {
         this.publisher.publishEvent(new TodosResetEvent());
         model.addAttribute("todos", this.repository.findAll());
-        return "todos :: todos";
+        return "todos :: todos-list";
     }
 
     @PostMapping
     HtmxResponse add(@RequestParam("new-todo") String newTodo, Model model) {
         log.debug("going to add another todo : " + newTodo);
-        this.repository.save(new Todo(null, newTodo));
-        model.addAttribute("todos", this.repository.findAll());
-        return new HtmxResponse()
-                .addTemplate("todos :: todos")
-                .addTemplate("todos :: todos-form");
+        Todo todo = this.repository.save(new Todo(null, newTodo));
+        model.addAttribute("todo", todo);
+        return HtmxResponse.builder()
+            .view("todo-item")
+            .view("todos :: todos-form")
+            .build();
     }
 
     @ResponseBody

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -1,0 +1,53 @@
+<html xmlns:th="http://www.thymeleaf.org" lang="en" th:fragment="header">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+	<title>My To Do List</title>
+	<script src="https://unpkg.com/htmx.org@2.0.0/dist/htmx.min.js"></script>
+	<style>
+
+		:root {
+			--gutter: 0.5em;
+		}
+
+		body {
+			padding: var(--gutter)
+		}
+
+		.line {
+			border-top: 1px solid black;
+			margin-top: var(--gutter);
+			padding-top: var(--gutter);
+
+		}
+
+		.title input[type=text] {
+			width: calc(100% - var(--gutter));
+		}
+
+		.todo {
+			grid-gap: var(--gutter);
+			display: grid;
+			grid: 'id  title buttons';
+			grid-template-columns: 3vw auto 20vw;
+		}
+
+
+		.todo .buttons {
+			grid-area: buttons;
+		}
+
+		.todo .title {
+			grid-area: title;
+			text-align: left;
+
+		}
+
+		.todo .id {
+			grid-area: id;
+			text-align: right;
+		}
+	</style>
+</head>

--- a/src/main/resources/templates/todo-item.html
+++ b/src/main/resources/templates/todo-item.html
@@ -1,0 +1,13 @@
+<div th:fragment="todo-item"
+		 class="todo line">
+	<div th:text="${todo.id}" class="id">243</div>
+	<div class="title" th:text="${todo.title}">title</div>
+	<div class="buttons">
+		<button hx-confirm="Are you sure?"
+						hx-target="closest .todo"
+						hx-swap="outerHTML"
+						th:hx-delete="${'/todos/' + todo.id}">
+			Delete
+		</button>
+	</div>
+</div>

--- a/src/main/resources/templates/todos.html
+++ b/src/main/resources/templates/todos.html
@@ -1,102 +1,41 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <title> My To Do List
-    </title>
-    <script src="https://unpkg.com/htmx.org@1.9.3"></script>
-    <style>
-
-        :root {
-            --gutter : 0.5em;
-        }
-        body {
-            padding: var(--gutter)
-        }
-
-        .line {
-
-            border-top: 1px solid black;
-            margin-top: var(--gutter);
-            padding-top: var(--gutter);
-
-        }
-
-        .title input[type=text] {
-            width: calc(100% - var(--gutter));
-        }
-
-        .todo {
-
-            grid-gap:  var(--gutter) ;
-            display: grid;
-            grid: 'id  title buttons';
-            grid-template-columns: 3vw auto 20vw;
-        }
-
-
-        .todo .buttons {
-            grid-area: buttons;
-        }
-
-        .todo .title {
-            grid-area: title;
-            text-align: left;
-
-        }
-
-        .todo .id {
-            grid-area: id;
-            text-align: right;
-        }
-    </style>
-</head>
+<header th:replace="header.html :: header"></header>
 <body>
 
-<div class="todos-list">
-    <div th:each="todo: ${todos}" th:fragment="todos" class="todo line">
-        <div class="id" th:text="${todo.id}">243</div>
-        <div class="title" th:text="${todo.title}"> title</div>
-        <div class="buttons">
-            <button hx-confirm="Are you sure?"
-                    hx-target="closest .todo"
-                    hx-swap="outerHTML"
-                    class="btn btn-danger"
-                    hx-trigger="click"
-                    th:attr="hx-delete=@{/todos/{id}(id=${todo.id})}">
-                Delete
-            </button>
-        </div>
-    </div>
+<div th:fragment="todos-list" id="todos-list">
+    <div th:each="todo: ${todos}" th:insert="todo-item.html :: todo-item"></div>
 </div>
-<div id="todos-form" th:fragment="todos-form" hx-swap-oob="true" class="todos-form">
+
+<div th:fragment="todos-form"
+     id="todos-form"
+     hx-swap-oob="true"
+     class="todos-form">
+
     <div class="todo line ">
-        <div></div>
+
         <div class="title">
-            <input type="text" name="new-todo" id="new-todo"/>
+            <input type="text" name="new-todo" id="new-todo" required/>
         </div>
+
         <div class="buttons">
             <button
-                    hx-include="#new-todo"
-                    hx-post="/todos"
-                    hx-target=".todos-list"
-                    hx-trigger="click">
+                hx-include="#new-todo"
+                hx-post="/todos"
+                hx-target="#todos-list"
+                hx-swap="beforeend">
                 Add
             </button>
         </div>
+
     </div>
 </div>
-<div class="line">
 
+<div class="line">
     <button hx-post="/todos/reset"
-            hx-target=".todos-list">
+            hx-target="#todos-list">
         Reset All
     </button>
 </div>
-
 
 </body>
 </html>


### PR DESCRIPTION
Hello @joshlong, saw your VOD today for this demo and thought it be a good learning exercise to try to optimize the logic where the Todo items are returned after adding a new one such that only that new one would be returned instead of the whole list again.

A new todo-item fragment was created for this purpose alongside a header fragment to clean up todos.html.

I also took the opportunity to upgrade the versions of the dependencies to their latest and java 21.

This was a fun exercise, feel free to reject or make suggestions to this PR :)